### PR TITLE
refactor(logging): align orchestrator logger fallback

### DIFF
--- a/src/a2a_t/client/prompt_generation/prompt_generation_orchestrator.py
+++ b/src/a2a_t/client/prompt_generation/prompt_generation_orchestrator.py
@@ -34,7 +34,7 @@ from .input_normalizer import InputNormalizer
 from .models import PromptGenerationFailure, PromptGenerationResult
 
 
-logger = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 
 class PromptGenerationOrchestrator:
@@ -63,7 +63,7 @@ class PromptGenerationOrchestrator:
         self._slot_extractor = slot_extractor
         self._input_normalizer = input_normalizer or InputNormalizer()
         self._renderer = renderer or TaskPromptRenderer()
-        self._logger = logger or globals()["logger"]
+        self._logger = logger if logger is not None else _LOGGER
 
     def generate(self, user_input: str | dict[str, object]) -> PromptGenerationResult:
         """Run prompt generation from input normalization through prompt rendering."""

--- a/src/a2a_t/negotiation/runtime/base_negotiation_orchestrator.py
+++ b/src/a2a_t/negotiation/runtime/base_negotiation_orchestrator.py
@@ -7,7 +7,7 @@ from a2a_t.negotiation.common.enums import NegotiationRole
 from a2a_t.negotiation.common.models import ContinueNegotiationInput, StartNegotiationInput
 
 
-logger = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 
 class BaseNegotiationOrchestrator:
@@ -16,7 +16,7 @@ class BaseNegotiationOrchestrator:
     def __init__(self, *, handler, role: NegotiationRole, logger: Any | None = None) -> None:
         self._handler = handler
         self._role = role
-        self._logger = logger or globals()["logger"]
+        self._logger = logger if logger is not None else _LOGGER
 
     def start_negotiation(self, input: StartNegotiationInput) -> dict[str, object]:
         """Start a negotiation from the bound local role."""
@@ -66,5 +66,4 @@ class BaseNegotiationOrchestrator:
         )
 
     def _log_info(self, message: str, *args: object) -> None:
-        if self._logger is not None and hasattr(self._logger, "info"):
-            self._logger.info(message, *args)
+        self._logger.info(message, *args)

--- a/src/a2a_t/server/prompt_compliance/prompt_compliance_orchestrator.py
+++ b/src/a2a_t/server/prompt_compliance/prompt_compliance_orchestrator.py
@@ -33,7 +33,7 @@ from a2a_t.server.prompt_compliance.constants import (
 )
 
 
-logger = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 
 class PromptComplianceOrchestrator:
@@ -58,7 +58,7 @@ class PromptComplianceOrchestrator:
         self._extractor = extractor
         self._validator = validator
         self._semantic_validator = semantic_validator
-        self._logger = logger or globals()["logger"]
+        self._logger = logger if logger is not None else _LOGGER
 
     def check(
         self,
@@ -210,5 +210,4 @@ class PromptComplianceOrchestrator:
 
     def _log_info(self, message: str, *args: object) -> None:
         """Write an info log through the configured logger."""
-        if self._logger is not None and hasattr(self._logger, "info"):
-            self._logger.info(message, *args)
+        self._logger.info(message, *args)

--- a/tests/client_prompt/test_orchestrator.py
+++ b/tests/client_prompt/test_orchestrator.py
@@ -141,6 +141,11 @@ class FakeLogger:
         self.debug_calls.append(message % args if args else message)
 
 
+class FalsyLogger(FakeLogger):
+    def __bool__(self) -> bool:
+        return False
+
+
 class FakeRenderer:
     def __init__(self, error: Exception) -> None:
         self._error = error
@@ -203,7 +208,7 @@ class PromptGenerationOrchestratorTest(unittest.TestCase):
         self.slot_schema_loader = slot_schema_loader or FakeSlotSchemaLoader()
         self.prompt_resource_loader = prompt_resource_loader or FakePromptResourceLoader()
         self.slot_extractor = slot_extractor or FakeSlotExtractor(extraction_result)
-        self.logger = logger or FakeLogger()
+        self.logger = logger if logger is not None else FakeLogger()
 
         return PromptGenerationOrchestrator(
             config=FakePromptRuntimeConfig(
@@ -283,6 +288,30 @@ class PromptGenerationOrchestratorTest(unittest.TestCase):
         )
         self.assertIsNone(result.failure)
         self.assertEqual(result.prompt_text, "Site: Site A\nNotes: ")
+
+    def test_orchestrator_uses_explicit_logger_even_when_logger_is_falsy(self) -> None:
+        logger = FalsyLogger()
+        orchestrator = self._build_orchestrator(
+            scenario_result=ScenarioResolutionResult(
+                success=True,
+                reference=PromptReference(scenario_code="energy_saving", language="en-US"),
+                scenario=ScenarioDefinition(
+                    scenario_code="energy_saving",
+                    scenario_name="Energy Saving",
+                    description="Used for energy saving analysis.",
+                    example="Analyze site power usage and suggest optimization.",
+                ),
+            ),
+            extraction_result=SlotExtractionResult(
+                slots={"site": "Site A", "additional_notes": None},
+                slot_errors=[],
+            ),
+            logger=logger,
+        )
+
+        orchestrator.generate("Analyze Site A energy usage.")
+
+        self.assertIn("prompt_generation_started", logger.info_calls)
 
     def test_generate_returns_success_result_when_extracted_slots_are_missing(self) -> None:
         orchestrator = self._build_orchestrator(

--- a/tests/negotiation/test_orchestrators.py
+++ b/tests/negotiation/test_orchestrators.py
@@ -51,6 +51,11 @@ class FakeLogger:
         self.info_messages.append((message, args))
 
 
+class FalsyLogger(FakeLogger):
+    def __bool__(self) -> bool:
+        return False
+
+
 class NegotiationOrchestratorTest(unittest.TestCase):
     def test_client_orchestrator_start_negotiation_uses_client_role(self) -> None:
         from a2a_t.negotiation.common.enums import NegotiationRole, NegotiationType
@@ -143,6 +148,30 @@ class NegotiationOrchestratorTest(unittest.TestCase):
         self.assertEqual(result, {"continued": True})
         self.assertEqual(len(handler.continue_calls), 1)
         self.assertEqual(handler.continue_calls[0]["input"].context.negotiation_id, "neg-1")
+
+    def test_orchestrator_uses_explicit_logger_even_when_logger_is_falsy(self) -> None:
+        from a2a_t.negotiation.common.enums import NegotiationType
+        from a2a_t.negotiation.common.models import StartNegotiationInput
+        from a2a_t.server.negotiation.negotiation_orchestrator import NegotiationOrchestrator
+
+        logger = FalsyLogger()
+        orchestrator = NegotiationOrchestrator(
+            handler=FakeNegotiationHandler(),
+            logger=logger,
+        )
+
+        orchestrator.start_negotiation(
+            StartNegotiationInput(
+                type=NegotiationType.INFORMATION,
+                content_text="Need more information.",
+                facts={},
+            )
+        )
+
+        self.assertIn(
+            ("negotiation_start_started role=%s type=%s", ("server", "information")),
+            logger.info_messages,
+        )
 
     def test_orchestrator_logs_lifecycle_events_without_message_content(self) -> None:
         from a2a_t.negotiation.common.enums import NegotiationStatus, NegotiationType

--- a/tests/prompt_compliance/test_service_runtime.py
+++ b/tests/prompt_compliance/test_service_runtime.py
@@ -150,6 +150,11 @@ class FakeLogger:
         self.info_messages.append((message, args))
 
 
+class FalsyLogger(FakeLogger):
+    def __bool__(self) -> bool:
+        return False
+
+
 class PromptComplianceOrchestratorRuntimeTest(unittest.TestCase):
     def setUp(self) -> None:
         self.processed_prompt = "processed body"
@@ -379,6 +384,14 @@ class PromptComplianceOrchestratorRuntimeTest(unittest.TestCase):
         self.assertIn("prompt_compliance_started", messages)
         self.assertTrue(any(message.startswith("prompt_compliance_scenario_resolved") for message in messages))
         self.assertTrue(any(message.startswith("prompt_compliance_completed") for message in messages))
+
+    def test_check_uses_explicit_logger_even_when_logger_is_falsy(self) -> None:
+        logger = FalsyLogger()
+        service = self._build_service(logger=logger)
+
+        service.check(processed_prompt_text=self.processed_prompt)
+
+        self.assertIn(("prompt_compliance_started", ()), logger.info_messages)
 
     def test_check_logs_failure_stage_and_code(self) -> None:
         logger = FakeLogger()


### PR DESCRIPTION
## Description

Align orchestrator logger fallback behavior across prompt generation, prompt compliance, and negotiation runtime.

- Use module-level `_LOGGER` fallback only when `logger is None`
- Preserve explicitly supplied logger objects even when they are falsy
- Add regression tests for the three orchestrator paths

## Related Issue(s)

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Other (describe below)

Refactor: normalize internal logger fallback behavior.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [ ] I have added or updated documentation as needed
- [ ] New source files include the SPDX license header

## Additional Context

Verification:

- `python -m pytest` -> 171 passed
- `git diff --check origin/main..HEAD` -> passed