### PR TITLE
ci: add A2A-T template lint gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install SDK dependencies
         run: uv sync --frozen
 
+      - name: Lint bundled A2A-T templates
+        run: uv run python tools/template_lint.py --resource-root package_data/prompt_resources
+
       - name: Install samples dependencies
         run: uv pip install -r a2a-t-sample/requirements.txt
 

--- a/tests/test_template_lint.py
+++ b/tests/test_template_lint.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+LINTER_PATH = Path(__file__).parents[1] / "tools" / "template_lint.py"
+SPEC = importlib.util.spec_from_file_location("template_lint", LINTER_PATH)
+assert SPEC is not None and SPEC.loader is not None
+template_lint = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = template_lint
+SPEC.loader.exec_module(template_lint)
+
+
+def test_bundled_templates_pass_static_lint() -> None:
+    root = Path(__file__).parents[1] / "package_data" / "prompt_resources"
+    assert template_lint.lint_resource_root(root) == []
+
+
+def test_linter_reports_missing_instruction_and_slot_contract_errors(tmp_path: Path) -> None:
+    root = tmp_path / "prompt_resources"
+    template_path = root / "templates" / "example" / "en-US" / "template.md"
+    schema_path = root / "slots" / "example" / "en-US" / "slot.json"
+    template_path.parent.mkdir(parents=True)
+    schema_path.parent.mkdir(parents=True)
+    template_path.write_text("## Task Type\nFault diagnosis\n\n{{unknown_slot}}\n", encoding="utf-8")
+    schema_path.write_text(json.dumps({"type": "object", "properties": {"unused_slot": {"type": "string"}}}), encoding="utf-8")
+
+    rules = {error.rule for error in template_lint.lint_resource_root(root)}
+
+    assert {"instruction-required", "slot-undefined", "slot-unused"} <= rules

--- a/tools/template_lint.py
+++ b/tools/template_lint.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Deterministic structural validation for bundled A2A-T prompt templates.
+
+This linter intentionally does not call an LLM.  It checks the parts of an
+A2A-T template that are safe to enforce in CI: the L0 instruction structure,
+Markdown heading syntax, and the contract between template placeholders and
+the paired slot JSON Schema.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+PLACEHOLDER_PATTERN = re.compile(r"{{\s*([^{}\s]+)\s*}}")
+
+TASK_HEADINGS = {
+    "Task Description",
+    "Task Type",
+    "Task Target",
+    "Task Object",
+    "Task Context",
+    "Constraints",
+    "Expected Output",
+}
+NOTIFICATION_HEADINGS = {
+    "Subscription Description",
+    "Notification Topic",
+    "Subscribe Condition",
+    "Notification Data Format",
+    "Expected Output",
+}
+HEADING_ALIASES = {
+    "任务描述": "Task Description",
+    "任务类型": "Task Type",
+    "任务目标": "Task Target",
+    "任务对象": "Task Object",
+    "目标对象": "Task Object",
+    "任务上下文": "Task Context",
+    "约束条件": "Constraints",
+    "预期输出": "Expected Output",
+    "订阅描述": "Subscription Description",
+    "通知主题": "Notification Topic",
+    "订阅条件": "Subscribe Condition",
+    "通知数据格式": "Notification Data Format",
+    "上报通知数据格式": "Notification Data Format",
+}
+
+
+@dataclass(frozen=True)
+class LintError:
+    path: Path
+    line: int
+    rule: str
+    message: str
+
+    def __str__(self) -> str:
+        return f"{self.path}:{self.line}: [{self.rule}] {self.message}"
+
+
+def canonical_heading(value: str) -> str:
+    """Return the canonical heading, accepting bilingual display headings."""
+    normalized = value.strip()
+    if normalized in TASK_HEADINGS | NOTIFICATION_HEADINGS:
+        return normalized
+    match = re.fullmatch(r"(.+?)\s*\(([^)]+)\)", normalized)
+    candidates = (normalized,) if match is None else (match.group(1).strip(), match.group(2).strip())
+    for candidate in candidates:
+        if candidate in HEADING_ALIASES:
+            return HEADING_ALIASES[candidate]
+        if candidate in TASK_HEADINGS | NOTIFICATION_HEADINGS:
+            return candidate
+    return normalized
+
+
+def load_schema(schema_path: Path, errors: list[LintError]) -> set[str]:
+    try:
+        data = json.loads(schema_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        errors.append(LintError(schema_path, 1, "schema-json", f"Cannot load JSON Schema: {error}"))
+        return set()
+    properties = data.get("properties")
+    if not isinstance(properties, dict):
+        errors.append(LintError(schema_path, 1, "schema-properties", "Schema must define an object 'properties'."))
+        return set()
+    property_names = set(properties)
+    required = data.get("required", [])
+    if not isinstance(required, list) or not all(isinstance(item, str) for item in required):
+        errors.append(LintError(schema_path, 1, "schema-required", "Schema 'required' must be an array of strings."))
+    else:
+        for name in required:
+            if name not in property_names:
+                errors.append(
+                    LintError(schema_path, 1, "schema-required", f"Required slot '{name}' is not in properties.")
+                )
+    return property_names
+
+
+def lint_template(template_path: Path, schema_path: Path) -> list[LintError]:
+    errors: list[LintError] = []
+    schema_slots = load_schema(schema_path, errors)
+    try:
+        lines = template_path.read_text(encoding="utf-8").splitlines()
+    except OSError as error:
+        return [*errors, LintError(template_path, 1, "template-read", f"Cannot read template: {error}")]
+
+    headings: list[tuple[int, str, int]] = []
+    placeholders: list[tuple[int, str]] = []
+    for line_number, line in enumerate(lines, start=1):
+        heading_match = HEADING_PATTERN.match(line)
+        if heading_match:
+            level = len(heading_match.group(1))
+            if level == 2:
+                headings.append((line_number, canonical_heading(heading_match.group(2)), level))
+        placeholders.extend((line_number, slot) for slot in PLACEHOLDER_PATTERN.findall(line))
+
+    heading_names = [name for _, name, _ in headings]
+    profile = "notification" if "Subscription Description" in heading_names else "task"
+    allowed_headings = NOTIFICATION_HEADINGS if profile == "notification" else TASK_HEADINGS
+    required_headings = {"Subscription Description"} if profile == "notification" else {"Task Description"}
+
+    if not headings:
+        errors.append(
+            LintError(
+                template_path,
+                1,
+                "instruction-missing",
+                "Template must contain L0 instructions marked with '##'.",
+            )
+        )
+    for line_number, name, _ in headings:
+        if name not in allowed_headings:
+            errors.append(
+                LintError(
+                    template_path,
+                    line_number,
+                    "instruction-name",
+                    f"'{name}' is not valid for the {profile} profile.",
+                )
+            )
+    for name in sorted(required_headings - set(heading_names)):
+        errors.append(LintError(template_path, 1, "instruction-required", f"Missing required instruction '{name}'."))
+    for name in sorted(set(heading_names)):
+        occurrences = [line for line, heading, _ in headings if heading == name]
+        if len(occurrences) > 1:
+            errors.append(
+                LintError(template_path, occurrences[1], "instruction-duplicate", f"Instruction '{name}' is repeated.")
+            )
+
+    seen_slots: set[str] = set()
+    for line_number, slot in placeholders:
+        if slot in seen_slots:
+            continue
+        seen_slots.add(slot)
+        if slot not in schema_slots:
+            errors.append(
+                LintError(
+                    template_path,
+                    line_number,
+                    "slot-undefined",
+                    f"Placeholder '{{{{{slot}}}}}' is missing from {schema_path.name}.",
+                )
+            )
+    for slot in sorted(schema_slots - seen_slots):
+        errors.append(LintError(schema_path, 1, "slot-unused", f"Schema slot '{slot}' has no template placeholder."))
+    return errors
+
+
+def lint_resource_root(resource_root: Path) -> list[LintError]:
+    errors: list[LintError] = []
+    templates_root = resource_root / "templates"
+    slots_root = resource_root / "slots"
+    if not templates_root.is_dir():
+        return [LintError(templates_root, 1, "resource-root", "Missing templates directory.")]
+    if not slots_root.is_dir():
+        return [LintError(slots_root, 1, "resource-root", "Missing slots directory.")]
+    for template_path in sorted(templates_root.glob("*/*/template.md")):
+        relative = template_path.relative_to(templates_root)
+        schema_path = slots_root / relative.parent / "slot.json"
+        if not schema_path.is_file():
+            errors.append(
+                LintError(template_path, 1, "slot-schema-missing", f"Missing paired slot schema: {schema_path}")
+            )
+            continue
+        errors.extend(lint_template(template_path, schema_path))
+    for schema_path in sorted(slots_root.glob("*/*/slot.json")):
+        relative = schema_path.relative_to(slots_root)
+        template_path = templates_root / relative.parent / "template.md"
+        if not template_path.is_file():
+            errors.append(LintError(schema_path, 1, "template-missing", f"Missing paired template: {template_path}"))
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--resource-root", type=Path, required=True, help="Path to prompt_resources.")
+    args = parser.parse_args()
+    errors = lint_resource_root(args.resource_root)
+    for error in errors:
+        print(error, file=sys.stderr)
+    if errors:
+        print(f"A2A-T template lint failed with {len(errors)} error(s).", file=sys.stderr)
+        return 1
+    print(f"A2A-T template lint passed: {args.resource_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Summary: add static validation for bundled A2A-T templates and slot schemas, run it in CI, and add linter tests. Validation: template linter and uv run pytest -q passed.