### PR TITLE
docs: add design documentation structure with AGENTS.md guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+Guidance for AI coding assistants working in this repository. Read this before making changes.
+
+## Project Overview
+
+`a2a-t-sdk-python` is a Python SDK for the A2A-T Extension, based on the A2A protocol.
+It supports `Task-T`, `Notification-T`, `Negotiation-T`, `Authorization-T` extensions. 
+Main features include A2A-T message generation, prompt compliance validation, negotiation flow management.
+
+## Key Guidelines
+
+- Before any design or development task, read `design/AGENTS.md` for the full workflow, stage-specific triggers, and design directory structure.
+- Base fixes, reviews, and technical judgments on source code, call sites, tests, and dependency contracts; do not conclude from memory.
+- Always update design spec and documents before changing the code. Keep them in sync. If implementation conflicts with the design, determine which is correct.
+- Always use the test-driven-development workflow to develop code.
+- Follow Python best practices and idiomatic patterns. Follow software principles such as DRY and YAGNI.
+- Maintain existing code structure and organization.
+- Keep diffs as minimal as possible.
+- Document public APIs and complex logic.
+- No bare except, raise typed SDK errors.
+- Write unit tests for new functionality focusing on behavior and not implementation.

--- a/design/AGENTS.md
+++ b/design/AGENTS.md
@@ -1,0 +1,54 @@
+# Design
+
+This directory contains design documents, architectural decisions, and development guides for the project. It serves as the source of truth for design facts, architectural rationale, and engineering standards.
+
+Documents in this directory support code modification, review, regression judgment, and new-contributor understanding. Do not put one-off task plans, meeting notes, or implementation logs here.
+
+## Directory Structure
+
+| Directory | Purpose | When to load |
+| --- | --- | --- |
+| `guide/` | Development conventions and guides | Design, coding, and submission stages |
+| `spec/` | Feature specifications and protocol definitions | Design and coding stages — when designing new capabilities or modifying existing ones |
+| `decision/` | Architecture Decision Records (ADR) | Design and coding stages — when creating or understanding architectural decisions |
+| `impl/` | Code-level implementation design (package structure, class design, method signatures, pseudo-code) | Coding stage — when implementing features with a corresponding spec |
+
+## Reading Rules
+
+Before entering any subdirectory, read that subdirectory's `AGENTS.md` first for navigation and indexing.
+
+## Loading Order
+
+1. Start with `guide/architecture.md` for project structure and key patterns.
+2. Read `guide/design-principles.md` for design constraints before writing spec or impl documents.
+3. Read `guide/coding-style.md` and `guide/testing.md` before writing code.
+4. Consult `spec/` and `decision/` when designing new features or questioning existing design.
+5. Check `guide/security.md` for secrets handling, `guide/git-workflow.md` for CI/CD.
+6. Consult `impl/` when implementing features to understand class-level design.
+
+## Work-Stage Triggers
+
+Before starting work, confirm the required reading/actions for the stage you are in.
+
+### Design Stage
+
+Read `guide/architecture.md` + `guide/design-principles.md` + `guide/security.md`.
+Consult `spec/` and `decision/` for existing design decisions.
+
+### Coding Stage
+
+Ensure a corresponding spec and impl document exist before writing code.
+Read `guide/design-principles.md` + `guide/coding-style.md` + `guide/testing.md` + `guide/security.md`.
+Consult `impl/` for class-level design.
+
+### Submission Stage
+
+Read `guide/git-workflow.md`. Follow its submission checklist.
+
+## Update Rules
+
+- Spec and impl documents describe current repository facts. When implementation conflicts with an impl or a spec document, determine whether the implementation deviates from design or the design document is outdated.
+- ADRs are not rewritten in place. An ADR with no "Superseded by" field is the latest decision for its scope. When decisions change, create a new ADR and update the supersession fields.
+- Guide documents describe current engineering practices. When practices deviate from the guide, either fix the practice or update the guide.
+- When adding a new document, update the corresponding subdirectory `AGENTS.md` index.
+- When unsure whether a document update is needed, state the judgment basis and residual risk in the delivery notes.

--- a/design/decision/AGENTS.md
+++ b/design/decision/AGENTS.md
@@ -1,0 +1,93 @@
+# Architecture Decision Records
+
+This directory records major architecture-level decisions. An ADR explains why a particular architectural choice was made, and what constraints and consequences that choice brings.
+
+## When to Create or Update an ADR
+
+Create a new ADR when:
+
+- Significant module boundary or responsibility assignment changes.
+- Key technology choices change.
+- Protocols, communication methods, middleware, or storage solutions change.
+- Runtime architecture, deployment topology, or dependency relationships change.
+- Significant data model, persistence format, or compatibility strategy changes.
+- Public API breaking changes or versioning strategy changes.
+- Authentication, authorization, key management, audit, or isolation security architecture changes.
+- Performance, reliability, or observability architecture-level constraints change.
+
+Do NOT create or update an ADR for:
+
+- Minor design changes — capture them in the corresponding spec only.
+- Documentation governance or AI workflows.
+- General coding conventions.
+- Test commands, CI flows, or publishing steps.
+- Task plans, meeting notes, or implementation steps.
+- Ordinary bug fixes, local refactoring, or code style adjustments.
+
+When a decision changes, create a new ADR — do not rewrite the existing one. Set the new ADR's "Supersedes" field to the old ADR, and update the old ADR's "Superseded by" field. Supersession is at the whole-ADR level — the new ADR replaces the entire scope of the old one, not a subset of it.
+When the decision itself has not changed but the document needs clarification, correction, or supplementary details, update the existing ADR directly.
+An ADR with no "Superseded by" field is the latest decision for its scope. No separate status field is needed; validity is derived from the supersede fields above.
+When unsure whether an ADR is needed, state the judgment basis and residual risk in the delivery notes.
+
+## Template
+When creating a new ADR, use the following template.
+**Overall constraint**:
+- This is a design document, not code or implementation. Do not write code implementations, class names, method signatures, or object definitions.
+- Do not write task plans, meeting notes, or implementation steps.
+- Do not write architecture descriptions or system design documents — focus on the decision and its rationale.
+- For sections that are not applicable, mark 'Not applicable' and state the reason.
+
+```markdown
+# Title
+
+- Impact Scope: concise description of the impact scope. Do not reference actual code
+- Related Spec: references to the corresponding spec document
+- Last Updated: YYYY-MM-DD
+- Supersedes:
+- Superseded by:
+
+## Context
+
+The background, constraints, and problem that led to this architectural decision.
+
+## Decision
+
+The chosen architectural approach.
+
+## Rationale
+
+The primary reasons for choosing this approach.
+
+## Alternatives
+
+### Option 1
+
+Why it was not chosen.
+
+### Option 2
+
+Why it was not chosen.
+
+## Consequences
+
+Positive impacts, costs, migration effort, and long-term constraints.
+
+## Verification
+
+How to verify that this decision still holds.
+```
+
+## Naming
+ADR files use four-digit sequential numbering and a descriptive title. Numbers are never reused.
+**examples**:
+```text
+0001-negotiation-state-storage.md
+```
+
+## Index
+When creating a new ADR, add a row to this table. When updating an existing ADR directly, update the `Last Updated` column. When an ADR is superseded, update the `Superseded by` column. When an ADR is no longer relevant, remove its row.
+
+| Number | Title | Last Updated | Superseded by |
+| --- | --- | --- | --- |
+
+*(No ADRs yet.)*

--- a/design/guide/AGENTS.md
+++ b/design/guide/AGENTS.md
@@ -1,0 +1,31 @@
+# Development Guides
+
+This directory contains project development conventions and guides. Guides describe engineering practices: how to write code, how to test, how to extend the system, and how to work with the toolchain.
+
+Design facts are in `../spec/`, architectural rationale in `../decision/`, and implementation details in `../impl/`.
+
+## When to Load
+
+Guides should be loaded in both design and coding stages:
+
+- **Design stage**: Read `architecture.md` for project structure and key patterns; read `design-principles.md` for design constraints and pattern selection.
+- **Coding stage**: Read `coding-style.md` and `testing.md` before writing or changing code.
+- **Submission stage**: Read `git-workflow.md` for CI/CD and submission checklist.
+
+## Directory
+
+| File | Content |
+| --- | --- |
+| [architecture.md](architecture.md) | Repository layout, Orchestrator+Builder, Factory+Registry, Protocol-based interfaces, error hierarchy |
+| [design-principles.md](design-principles.md) | Design constraints for spec and impl documents, pattern selection, SOLID principles |
+| [coding-style.md](coding-style.md) | Code conventions, type hints, imports, naming, error handling |
+| [testing.md](testing.md) | Test framework, style, conventions, shared helpers |
+| [security.md](security.md) | Secrets handling |
+| [git-workflow.md](git-workflow.md) | CI/CD, submission checklist, publishing |
+
+## Update Rules
+
+- Guides describe current practices. When practices deviate from the guide, either fix the practice or update the guide.
+- When adding a new guide, update this index.
+- When changing a guide's scope or content, ensure the `design/AGENTS.md` Work-Stage Triggers still reference the correct file.
+- Do not put one-off task plans, meeting notes, or implementation logs here.

--- a/design/guide/architecture.md
+++ b/design/guide/architecture.md
@@ -1,0 +1,60 @@
+# Architecture & Key Patterns
+
+## Repository Layout
+
+```
+src/a2a_t/            # SDK package (import name: a2a_t)
+  __init__.py         # lazy module loader via __getattr__
+  client/             # A2ATClient + prompt_generation/ + negotiation/
+  server/             # A2ATServer + prompt_compliance/ + negotiation/
+  common/             # prompt resource loading, prompt runtime, resource_roots.py
+  config/             # A2ATConfig, DotEnvConfigSource, config errors
+  llm/                # LLMClient Protocol, factory, config loader, providers/
+  negotiation/        # types/ (strategies), runtime/, store/, handling/, rendering/, common/
+  prompt/             # analysis/, task_rendering/, validation/, common/
+package_data/         # packaged data files shipped with the wheel
+  env.example         # template .env -> copy to package_data/.env
+  prompt_resources/   # prompts/, scenarios/, slots/, templates/
+tests/                # pytest suite; support.py holds shared helpers
+.github/workflows/    # ci.yml (test + advisory lint), publish.yml (PyPI on v* tags)
+```
+
+### Package Data Note
+
+`package_data/` is shipped with the wheel via `tool.uv.build-backend.data`. The prompt resources under `package_data/prompt_resources/` are resolved at runtime by `a2a_t/common/resource_roots.py::resolve_prompt_resource_root`, which handles **both** source checkouts (path relative to the module file) and installed wheels (`sysconfig.get_path("data")`). Resolution works in both source-checkout and installed-wheel layouts.
+
+## Orchestrator + Builder
+
+High-level `A2ATClient` / `A2ATServer` are thin facades. Each capability is a `*OrchestratorBuilder` that constructs a `*Orchestrator`, which does the real work. The facade delegates every public call.
+
+- `client/prompt_generation/prompt_generation_orchestrator_builder.py`
+- `client/negotiation/negotiation_orchestrator_builder.py`
+- `server/prompt_compliance/prompt_compliance_orchestrator_builder.py`
+- `server/negotiation/negotiation_orchestrator_builder.py`
+- `negotiation/runtime/base_negotiation_orchestrator.py`
+
+## Factory + Registry
+
+`a2a_t/llm/factory.py::LLMClientFactory` keeps a class-level `_clients` dict mapping provider name -> client class. New providers are registered via `LLMClientFactory.register()` and created via `LLMClientFactory.create()`. The negotiation state store follows the same pattern (`negotiation/store/factory.py`).
+
+## Protocol-based Interfaces
+
+`a2a_t/llm/provider.py::LLMClient` is a `@runtime_checkable Protocol` with a single `structured(...)` method. Provider clients (e.g. `providers/openai.py::OpenAIClient`) implement it structurally; inheritance is not required.
+
+## Configuration from .env
+
+All runtime config is read from a single `.env` file via `a2a_t/config/source.py::DotEnvConfigSource.load()`. Two loaders build typed dataclasses:
+
+- `a2a_t/config/models.py::A2ATConfig.load(env_path)` -> `PromptRuntimeConfig` + `PromptComplianceConfig`.
+- `a2a_t/llm/config_loader.py::LLMConfigLoader.load(env_path)` -> `LLMClientConfig`.
+
+Both validate and raise typed errors (`ConfigError`, `LLMConfigError`) on bad input. `A2ATClient` / `A2ATServer` default to `package_data/.env`; callers can pass `env_path=` to override.
+
+## Error Hierarchy
+
+- `config/errors.py`: `ConfigError` -> `ConfigFileNotFoundError`
+- `llm/errors.py`: `LLMError` -> `LLMConfigError`, `LLMRuntimeError`
+
+## Negotiation Types
+
+`negotiation/types/base.py::BaseNegotiationType` defines the default behavior (`render_start_prompt`, `process_received_message`, `render_continue_prompt`). Concrete strategies live alongside it: `information.py`, `feasibility.py`, `target.py`. They are registered in `negotiation/types/__init__.py`.

--- a/design/guide/coding-style.md
+++ b/design/guide/coding-style.md
@@ -1,0 +1,43 @@
+# Coding Style
+
+Enforced by `ruff` and `mypy` (strict). Do not fight the linter.
+
+## General Principles
+
+- Follow Python best practices and idiomatic patterns.
+- Follow software principles such as DRY and YAGNI.
+- Keep diffs as minimal as possible.
+- Do not add comments unless a non-obvious invariant requires explanation.
+
+## Imports & Module Structure
+
+- `from __future__ import annotations` at the top of every module.
+- Import ordering is enforced by ruff rule `I` (isort-compatible). Group stdlib, then third-party, then `a2a_t.*`.
+- Lazy imports: top-level `a2a_t/__init__.py` uses `__getattr__` to import submodules on demand. Keep heavy imports out of `__init__.py` unless they are cheap.
+
+## Type Hints
+
+- Type hints are **required** on all public functions; `mypy --strict` is the baseline.
+
+## Dataclasses
+
+Follow dataclass conventions from `design-principles.md`.
+
+## Formatting
+
+- Line length is 120.
+- Tests relax `E402` (module-level import not at top) and `E501` (line length) because they manipulate `sys.path` before importing `a2a_t`.
+
+## Naming
+
+Ruff rule `N` enforces PEP 8 naming:
+
+- Classes: `PascalCase`
+- Functions and variables: `snake_case`
+- Constants: `UPPER_SNAKE`
+
+## Error Handling
+
+- No bare except; catch specific exceptions and re-raise as SDK error types.
+- Never raise bare `Exception` in SDK code. Wrap provider errors into `LLMRuntimeError`.
+- Raise the most specific subclass available (see `config/errors.py`, `llm/errors.py`).

--- a/design/guide/design-principles.md
+++ b/design/guide/design-principles.md
@@ -1,0 +1,100 @@
+# Design Principles
+
+Design principles that must be followed when creating spec and impl documents. These principles are derived from the project's existing code patterns, not imposed from outside.
+
+## Architecture Design (for spec documents)
+
+Spec documents define capability boundaries, module interactions, and contracts. The following principles constrain how specs are designed.
+
+### Module Boundary
+
+A capability owns its data, its logic, and its error types. When a feature crosses module boundaries, define a clear contract: what data flows in, what data flows out, and which errors can propagate.
+
+- Prefer **narrow contracts** — expose only what downstream modules need.
+- A module should not reach into another module's internal data structures.
+- Cross-module dependencies should flow from high-level (orchestrator) to low-level (utility), not sideways.
+
+### Dependency Direction
+
+Dependencies must flow from high-level (orchestrator/facade) to low-level (utility/common). No circular dependencies. See `architecture.md` for the concrete layering.
+
+When adding a new capability, follow this layering: define the contract in a shared package, implement the logic in an orchestrator, expose it through the client or server facade.
+
+### Capability Decomposition
+
+A capability is a self-contained feature with a clear input/output boundary. When designing a spec:
+
+- One spec = one capability. Do not merge unrelated features into one spec.
+- If a feature has server-side and client-side responsibilities, they may share a spec but must clearly separate the two roles.
+- Do not prematurely split a capability into sub-features. Start with one spec and split when the spec becomes too large to reason about.
+
+### Error Hierarchy
+
+Every module that can fail must define its own error hierarchy:
+
+- One base error class per module (e.g., `LLMError`, `ConfigError`).
+- Specific subclasses for distinct failure modes (e.g., `LLMConfigError`, `LLMRuntimeError`).
+- Error types should carry enough context for callers to handle them programmatically (e.g., `ConfigFileNotFoundError` carries the file path).
+
+### Degradation Strategy
+
+When a dependency is optional or may fail, define a degradation strategy in the spec:
+
+- Fall back to a safe default (e.g., `NegotiationStateStoreFactory` falls back to in-memory store).
+- Log a warning — do not silently swallow errors.
+- Do not degrade across security boundaries.
+
+## Code Design (for impl documents)
+
+Impl documents translate architecture decisions into class-level design. The following principles constrain how code is organized.
+
+### SOLID Principles (Python-adapted)
+
+| Principle | In this project |
+|-----------|----------------|
+| **Single Responsibility (SRP)** | Each class does one thing. An orchestrator coordinates, a builder wires, a renderer renders. Do not merge them. |
+| **Open/Closed (OCP)** | Extend through new classes, not by modifying existing ones. Add a new negotiation type by subclassing `BaseNegotiationType`, not by adding branches to it. |
+| **Liskov Substitution (LSP)** | Subtypes must honor the contract of their base type. Override hook methods, not core logic methods. |
+| **Interface Segregation (ISP)** | Keep Protocols narrow. `LLMClient` exposes only `structured()`, not every capability an LLM might have. |
+| **Dependency Inversion (DIP)** | Depend on Protocols, not concrete classes. `LLMClientFactory` depends on `LLMClient` Protocol, not `OpenAIClient`. |
+
+### Python-Specific Principles
+
+**Composition over inheritance.** Prefer passing dependencies through constructors over inheriting behavior. `BaseNegotiationType` uses composition: it receives a `NegotiationPromptRenderer` via the constructor rather than inheriting rendering logic.
+
+**Protocol over ABC.** Use `typing.Protocol` for extension interfaces. Structural subtyping means implementers don't need to inherit — they just need the right method signatures. Use `@runtime_checkable` when `isinstance()` checks are needed.
+
+**Dataclasses for data, classes for behavior.** Use `@dataclass(slots=True)` for configuration objects, `@dataclass(frozen=True)` for immutable value objects. Use regular classes for objects with behavior.
+
+**Keyword-only parameters.** Use `*,` before non-self parameters on all public APIs. This makes call sites explicit and prevents positional argument confusion.
+
+**Explicit dependency wiring.** No global state, no service locators, no magic auto-wiring. Every dependency is passed through the constructor. Builders are the single place where wiring happens.
+
+### Project Patterns
+
+These patterns are proven in the existing codebase. New code should follow them.
+
+**Builder + Orchestrator.** High-level facades (`A2ATClient`, `A2ATServer`) are thin. Each capability has a `*OrchestratorBuilder` that constructs a `*Orchestrator`. The builder is the wiring point; the orchestrator is the logic point. Do not put logic in builders or wiring in orchestrators.
+
+**Factory + Registry.** For pluggable backends, use a class-level registry dict mapping name → class. The factory creates instances from the registry. See `LLMClientFactory` for the canonical pattern.
+
+**Strategy pattern for variant behavior.** When a behavior has multiple variants, define a base class with hook methods and subclass for each variant. The base class provides defaults; subclasses override only what they need. See `BaseNegotiationType` → `InformationNegotiationType`, `FeasibilityNegotiationType`, `TargetNegotiationType`.
+
+**Typed errors, typed results.** Orchestrator methods return either a success result or a failure result (not raise exceptions for expected failures). Use dedicated result types for the success path, error types for the failure path. See `PromptGenerationResult` / `PromptGenerationFailure`.
+
+### When to Abstract
+
+| Situation | Action |
+|-----------|--------|
+| Single implementation, no cross-module boundary | Concrete class. No abstraction needed. |
+| Single implementation, cross-module boundary | Define a Protocol so the caller doesn't depend on the implementation module. |
+| Multiple implementations expected | Protocol + Factory + Registry. |
+| Behavior variant within same module | Strategy pattern (base class + subclasses). |
+
+Do not abstract for hypothetical future needs. Abstract when a second implementation is actually needed, or when a cross-module boundary demands it.
+
+### Anti-Patterns
+
+**Middle Man.** A class that does nothing but delegate every method call to another class without adding logic. If a class is just a pass-through, remove it and let callers depend on the real implementation directly.
+
+**Premature Abstraction.** A Protocol or abstract class created for a single implementation "just in case." Wait until a second implementation exists before introducing the abstraction.

--- a/design/guide/git-workflow.md
+++ b/design/guide/git-workflow.md
@@ -1,0 +1,45 @@
+# Git Workflow & CI/CD
+
+## Commands
+
+The project uses `uv` as its package manager and build backend. Python `>=3.12` is required.
+
+```bash
+uv sync --dev                    # install deps (dev) locally
+uv run pytest                    # run all tests (see `testing.md`)
+uv run pytest tests/ -v --tb=short   # CI-style test run (see `testing.md`)
+uv run ruff check src tests      # lint
+uv run mypy src                  # type-check (strict)
+uv build --no-sources            # build distributions
+```
+
+## Submission Checklist
+
+Before committing or creating a PR:
+
+```bash
+uv run ruff check src tests
+uv run mypy src
+uv run pytest
+```
+
+Use `git commit -s` to sign off every commit.
+
+Do not commit planning artifacts (`findings.md`, `progress.md`, `task_plan.md`, `reference/`) — they are gitignored.
+
+## CI
+
+`.github/workflows/ci.yml`: runs on push to `main`/`master`/`develop` and PRs to `main`/`master`.
+
+- Job `test`: runs `uv run pytest tests/ -v --tb=short`.
+- Job `lint`: runs `ruff check src tests` + `mypy src` (advisory, `continue-on-error`).
+
+CI installs with `uv sync --frozen` (uses `uv.lock` exactly). Do not edit `uv.lock` by hand; run `uv sync` to update it after dependency changes. Before adding a dependency, confirm `pyproject.toml` does not already include an equivalent dependency.
+
+## Publishing
+
+`.github/workflows/publish.yml`: triggered by `v*` tags or manual dispatch. Builds with `uv build --no-sources` and publishes to PyPI via OIDC trusted publishing.
+
+## Code Owners
+
+`@project-openan/maintainers-a2a-t-sdk` (see `CODEOWNERS`, `MAINTAINERS.md`).

--- a/design/guide/security.md
+++ b/design/guide/security.md
@@ -1,0 +1,10 @@
+# Security
+
+## Secrets
+
+- Do not put real API keys or secrets in `tests/.env`, `package_data/.env`, or any committed file. Use placeholder values.
+- Before running the SDK locally, copy `package_data/env.example` to `package_data/.env` and fill in the `A2AT_LLM_*` values.
+
+## Package Data
+
+Don't bypass `resolve_prompt_resource_root` when locating packaged resources. This ensures the correct resolution path in both source-checkout and installed-wheel layouts.

--- a/design/guide/testing.md
+++ b/design/guide/testing.md
@@ -1,0 +1,31 @@
+# Testing
+
+## Framework
+
+`pytest` with `asyncio_mode = "auto"` and `testpaths = ["tests"]`.
+
+## Test Style
+
+- `unittest.TestCase` classes with `unittest.mock.patch` for fakes.
+- See `tests/client_prompt/test_a2at_client.py` for the canonical facade-delegation test.
+- Focus tests on **behavior**, not implementation details.
+
+## Shared Helpers
+
+`tests/support.py` provides:
+
+- `ManagedTempDirTestCase` — auto-cleans temp dirs under `.tmp_tests/`.
+- `FakeRemoteProvider`, `build_markdown`, `TEST_ENV_PATH`, `PROJECT_ROOT`.
+
+## Conventions
+
+- Tests add `src/` to `sys.path` so they run without an installed package.
+- Prefer fakes/builder doubles over real LLM calls. Unit tests must not hit the network.
+- When adding a feature, add a test file under the matching `tests/<area>/` subdir.
+
+## Running Tests
+
+```bash
+uv run pytest                          # run all tests
+uv run pytest tests/ -v --tb=short     # CI-style test run
+```

--- a/design/impl/AGENTS.md
+++ b/design/impl/AGENTS.md
@@ -1,0 +1,87 @@
+# Implementation Design
+
+This directory contains code-level implementation design documents. An implementation document translates a spec into package, class, and method-level design, plus pseudo-code for key logic. Its purpose is to verify that the code architecture is clear and reasonable before writing code — **it is not the final code itself**.
+
+Every spec in `../spec/` must have a corresponding implementation document. An implementation document must fully conform to its spec. Design facts are in `../spec/`, architectural rationale in `../decision/`.
+
+## When to Create or Update an Impl
+
+Create or update an implementation document when:
+
+- A corresponding spec is created or updated.
+- Class design, method signatures, or internal data structures change.
+- Pseudo-code or key algorithms change.
+
+Do NOT create or update an impl for:
+
+- Local refactoring that does not change class design or method signatures.
+- Code style, formatting, or comment adjustments.
+
+When modifying code that touches the scope above, always update the spec first, then the impl, then change the code.
+If implementation conflicts with the implementation document, verify against the spec first, then determine which is correct and update the implementation document if it is outdated, or fix the implementation if it deviates from the implementation document.
+When unsure whether an update is needed, state the judgment basis and residual risk in the delivery notes.
+
+All impl documents must follow the constraints in `../guide/architecture.md` and `../guide/coding-style.md`.
+
+## Template
+When creating a new impl, use the following template.
+**Overall constraint**:
+- This is a design document, not code. Do not write method bodies, field declarations, constructors, or any code implementation.
+- Do not write utility classes, helper functions, or object definitions (fields, constructors, data classes).
+- Do not write detailed implementation logic — one-line responsibility description is sufficient for non-core methods.
+- Do not write annotations, imports, copyright notices, or docstrings.
+- Do not include design facts or architectural decisions.
+- For sections that are not applicable, mark 'Not applicable' and state the reason.
+
+```markdown
+# Title
+
+- Impact Scope: concise description of the impact scope. Do not reference actual code
+- Related Spec: references to the corresponding spec document
+- Last Updated: YYYY-MM-DD
+
+## Design Patterns & Trade-offs
+
+Why this pattern was chosen. Alternatives considered and why they were rejected.
+
+## Package Structure
+
+Package layout and module responsibilities.
+
+## Class Design
+
+### ClassName
+
+- Responsibility:
+- Dependencies:
+- Method signatures (use lookup tables for mappings and configuration items when appropriate):
+
+  - `method_name(param: Type) -> ReturnType`
+
+## Key Algorithms
+
+Pseudo-code for core logic. Describe steps and constraints, not language syntax.
+
+## Unit Test Scenarios
+
+What scenarios to test. Describe test intent, not test implementation.
+
+## Design Constraints
+
+Key constraints and invariants that the implementation must satisfy.
+```
+
+## Naming
+Use the same name as the corresponding spec, ending with `-impl.md`.
+**examples**:
+```text
+negotiation-impl.md
+```
+
+## Index
+When creating a new impl, add a row to this table. When updating an existing impl, update the `Last Updated` column. When an impl is no longer relevant, remove its row.
+
+| Impl | Last Updated |
+| --- | --- |
+
+*(No implementation documents yet.)*

--- a/design/spec/AGENTS.md
+++ b/design/spec/AGENTS.md
@@ -1,0 +1,113 @@
+# Specifications
+
+This directory contains feature-level design specifications. A spec describes the current design facts: what problem this capability solves, what the boundaries are, what the call chain looks like, and what interfaces and data it depends on.
+
+## When to Create or Update a Spec
+
+Create or update a spec when:
+
+- Adding a new capability or changing capability boundaries.
+- Changing call chains, module responsibilities, or cross-module dependencies.
+- Changing public interfaces, events, configuration, data models, or state machines.
+- Changing authentication, authorization, permission boundaries, exception handling, or degradation strategies.
+- Changing critical flows, failure modes, observability, or testing strategies.
+
+Do NOT create or update a spec for:
+
+- Bug fixes that do not change design facts.
+- Local refactoring that does not change responsibility boundaries.
+- Code style, formatting, or comment adjustments.
+- One-off task plans, meeting notes, or implementation logs.
+
+Every spec must have a corresponding implementation document. Before writing code, ensure both spec and impl documents exist.
+
+When modifying code that touches the scope above, always update the spec first, then the impl, then change the code.
+If implementation conflicts with the spec, determine which is correct and update the spec if it is outdated, or fix the implementation if it deviates from the spec.
+If the change introduces or overturns an architectural-level choice, also check whether an ADR is needed in `../decision/`.
+When unsure whether a spec update is needed, state the judgment basis and residual risk in the delivery notes.
+
+## Template
+When creating a new spec, use the following template.
+**Overall constraint**:
+- This is a design document, not code or implementation. Do not write code implementations, class names, method signatures, or object definitions.
+- Do not describe class-level or code-level interactions — only describe business logic level interactions.
+- Do not reference specific code files, classes, or implementation details.
+- Keep descriptions concise — use diagrams and bullet points; do not use large blocks of prose.
+- For sections that are not applicable, mark 'Not applicable' and state the reason.
+
+```markdown
+# Title
+
+- Impact Scope: concise description of the impact scope. Do not reference actual code
+- Related ADR: references to related ADR documents
+- Related Impl: references to related impl documents
+- Last Updated: YYYY-MM-DD
+
+## Background
+Explain why this capability exists, what problem it solves, and key constraints. Keep it concise.
+
+## Goals
+List the business and engineering goals this design must achieve. Goals should be verifiable.
+
+## Non-Goals
+Explicitly state what this design does NOT cover, to prevent scope creep.
+
+## Core Concepts
+Define domain objects, key terminology, state machines, and invariants. Keep it at the conceptual level.
+
+## Boundaries
+Define what this capability owns and does not own at the functional and module level. Describe the boundaries with upstream/downstream modules. Cover:
+- Input boundary: what data/events it receives from which upstream module
+- Output boundary: what results it produces for which downstream module
+- Dependency boundary: what external modules/services it depends on
+
+## Key Interactions
+Describe the high-level interactions between modules. Use diagrams wherever possible.
+
+## Feature Design
+Organize by sub-scenario, sub-feature, or sub-flow. Each subsection should cover the following aspects.
+
+### Sub-scenario A
+
+#### Flow
+Describe the business process logic. Use diagrams wherever possible.
+
+#### Interfaces & Data
+Describe the external interfaces, input/output/internal data models, and database design involved in this sub-scenario. Only describe the contract.
+
+#### Exceptions
+Describe failure modes and error handling strategies. Merge common exception branches into unified handling when possible. For extreme edge cases, list them as known-unhandled. Keep it concise — do not write complex flows attempting to resolve extreme scenarios.
+
+#### Security
+Describe security considerations to cover: authentication, authorization, secret management, log redaction, data protection.
+
+#### Observability
+Describe what to instrument: log fields, metrics, traces, and alerts.
+
+#### Testing
+Describe business scenarios to cover and key regression scenarios. Provide a test matrix when necessary.
+
+#### Performance
+Describe performance considerations and constraints for this sub-scenario.
+
+### Sub-scenario B
+...
+
+## Open Questions
+Only record genuine unresolved questions. Do not write empty placeholder content.
+```
+
+## Naming
+Use the capability or feature name, ending with `-spec.md`.
+**examples**:
+```text
+negotiation-spec.md
+prompt-generation-spec.md
+```
+
+## Index
+When creating a new spec, add a row to this table. When updating an existing spec, update the `Last Updated` column. When a spec is no longer relevant, remove its row.
+
+| Spec | Last Updated |
+| --- | --- |
+*(No specs yet.)*


### PR DESCRIPTION
## Description
- Add root AGENTS.md as entry point delegating to design/AGENTS.md
- Add design/AGENTS.md with directory structure, loading order, work-stage triggers
- Add guide/ directory: architecture, design-principles, coding-style, testing, security, git-workflow
- Add spec/decision/impl AGENTS.md with templates and creation rules
- All design documents reviewed for consistency and cross-referencing

## Related Issue(s)

NA

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [ ] I have added tests that prove my fix is effective or my feature works (if applicable)
- [x] I have added or updated documentation as needed
- [ ] New source files include the SPDX license header

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here. -->
